### PR TITLE
Use the condaforge/miniforge3 base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,8 @@ FROM csdms/grpc4bmi:0.3.0
 LABEL author="Mark Piper"
 LABEL email="mark.piper@colorado.edu"
 
-RUN pip install grpc4bmi
+RUN pip install grpc4bmi && \
+    pip cache purge
 
 WORKDIR /opt
 ENV BMI_PORT=55555

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,10 @@
 # A grpc4bmi server for the bmi-example-python `Heat` model.
 FROM csdms/grpc4bmi:0.3.0
 
-LABEL author="Mark Piper"
-LABEL email="mark.piper@colorado.edu"
+LABEL org.opencontainers.image.authors="Mark Piper <mark.piper@colorado.edu>"
+LABEL org.opencontainers.image.source="https://github.com/csdms/bmi-example-python-grpc4bmi"
+LABEL org.opencontainers.image.url="https://hub.docker.com/r/csdms/bmi-example-python-grpc4bmi"
+LABEL org.opencontainers.image.vendor="CSDMS"
 
 RUN pip install grpc4bmi && \
     pip cache purge

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
-# Set up a grpc4bmi server to run the Python BMI example.
-FROM csdms/bmi-example-python:0.4.0
+# A grpc4bmi server for the bmi-example-python `Heat` model.
+FROM csdms/grpc4bmi:0.3.0
 
 LABEL author="Mark Piper"
 LABEL email="mark.piper@colorado.edu"


### PR DESCRIPTION
This PR updates the project to build on the condaforge/miniforge3 and csdms/bmi base images instead of the archived csdms/bmi-example-python base image.